### PR TITLE
feat: optimize email field for mobile keyboards

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <%= form_with scope: :session, url: session_path, id: "new-session" do |form| %>
   <div class="mdc-text-field mdc-text-field--box">
-    <%= form.text_field :email, class: "mdc-text-field__input", autofocus: true %>
+    <%= form.email_field :email, class: "mdc-text-field__input", autofocus: true %>
     <label class="mdc-floating-label" for="my-text-field">Email</label>
   </div>
 


### PR DESCRIPTION
This let mobile keyboard know this is an email field, so they type lowercase by default, plus making `@` more accessible.