### PR TITLE
Explicitly set UserVerificationRequirement to 'preferred'…

### DIFF
--- a/app/assets/javascripts/credentials.js
+++ b/app/assets/javascripts/credentials.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 
       credentialOptions["challenge"] = strToBin(credentialOptions["challenge"]);
       credentialOptions["user"]["id"] = strToBin(credentialOptions["user"]["id"]);
+      credentialOptions["authenticatorSelection"]["userVerification"] = "preferred";
       credential_nickname = document.querySelector("#add-credential input[name='credential[nickname]']").value;
       callback_url = `/credentials/callback?credential_nickname=${credential_nickname}`
 


### PR DESCRIPTION
…to trigger fingerprint option on Android Chrome 71. It would not show for me at all running the app locally without this.

Related to https://github.com/cedarcode/webauthn-rails-demo-app/issues/31 