### PR TITLE
Update tested browsers to include Android Chrome 70 and MS Edge 18

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,9 @@ module ApplicationHelper
 
   TESTED_BROWSERS = [
     Browser.new("Firefox", "60", false),
-    Browser.new("Chrome", "67", false)
+    Browser.new("Chrome", "67", false),
+    Browser.new("Chrome", "70", true),
+    Browser.new("Edge", "18", false),
   ].freeze
 
   def unsupported_browser_message


### PR DESCRIPTION
Tested MS Edge on Windows 10 Insider build 18252. User agent is `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.18252`

![microsoft edge 2018-10-13 19-06-06](https://user-images.githubusercontent.com/496367/46911409-988fc300-cf28-11e8-9cd2-93561f38a3ad.gif)
