### PR TITLE
ci: cache node modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ dist: xenial
 addons:
   chrome: stable
 language: ruby
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - node_modules
 
 services:
   - postgresql


### PR DESCRIPTION
Speed up `yarn install` from ~20s to 1s per build by caching `node_modules` directory.