### PR TITLE
Remove unnecessary user handle hack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/cedarcode/webauthn-ruby.git
-  revision: 4b86238aafb51d492b08cfdc0e8c1b296e02849f
+  revision: 9151047b020311a10d168168e64d74c9e8a1568f
   specs:
     webauthn (1.18.0)
       bindata (~> 2.4)

--- a/test/system/sign_in_test.rb
+++ b/test/system/sign_in_test.rb
@@ -28,10 +28,6 @@ class SignInTest < ApplicationSystemTestCase
     visit new_session_path
 
     fake_assertion = fake_client.get(challenge: fixed_challenge)
-
-    # Temporary until https://github.com/cedarcode/webauthn-ruby/issues/246 is fixed
-    fake_assertion["response"]["userHandle"] = nil
-
     stub_get(fake_assertion)
 
     fill_in "Username", with: "User1"


### PR DESCRIPTION
Latest version of `webauthn-ruby` gem now returns `userHandle` field