### PR TITLE
Update `webauthn-json` to `v2.1.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "yarn": ">=1.7.0"
   },
   "dependencies": {
-    "@github/webauthn-json": "^0.4.5",
+    "@github/webauthn-json": "^2.1.1",
     "@material/button": "~4.0.0",
     "@material/card": "~4.0.0",
     "@material/list": "~4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1003,10 +1003,10 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@github/webauthn-json@^0.4.5":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@github/webauthn-json/-/webauthn-json-0.4.5.tgz#05bad0193597907c81a8bf7dd67870f1ab03658e"
-  integrity sha512-pVBGDtiHXPEK6Qycqt5yrHBfjpxlJ9MBMh5taKVosnvWNelwOtnwiXIOxVxFULwOtcZ0x65oIzh2Vz8oUq5tew==
+"@github/webauthn-json@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@github/webauthn-json/-/webauthn-json-2.1.1.tgz#648e63fc28050917d2882cc2b27817a88cb420fc"
+  integrity sha512-XrftRn4z75SnaJOmZQbt7Mk+IIjqVHw+glDGOxuHwXkZBZh/MBoRS7MHjSZMDaLhT4RjN2VqiEU7EOYleuJWSQ==
 
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"


### PR DESCRIPTION
## Summary

We were using a really old version of `webauthn-json` meaning that we were missing some features that were added to the WebAuthn API – see https://github.com/cedarcode/webauthn-ruby/pull/370.