### PR TITLE
Unify data acquisition for `Hash` class

### DIFF
--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -21,7 +21,7 @@ class CredentialsController < ApplicationController
   def callback
     webauthn_credential = relying_party.verify_registration(
       params,
-      session["current_registration"]["challenge"],
+      session[:current_registration][:challenge],
       user_verification: true,
     )
 
@@ -41,7 +41,7 @@ class CredentialsController < ApplicationController
   rescue WebAuthn::Error => e
     render json: "Verification failed: #{e.message}", status: :unprocessable_entity
   ensure
-    session.delete("current_registration")
+    session.delete(:current_registration)
   end
 
   def destroy

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -29,12 +29,12 @@ class RegistrationsController < ApplicationController
   end
 
   def callback
-    user = User.create!(session["current_registration"]["user_attributes"])
+    user = User.create!(session[:current_registration][:user_attributes])
 
     begin
       webauthn_credential = relying_party.verify_registration(
         params,
-        session["current_registration"]["challenge"],
+        session[:current_registration][:challenge],
         user_verification: true,
       )
 
@@ -55,7 +55,7 @@ class RegistrationsController < ApplicationController
     rescue WebAuthn::Error => e
       render json: "Verification failed: #{e.message}", status: :unprocessable_entity
     ensure
-      session.delete("current_registration")
+      session.delete(:current_registration)
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,13 +26,13 @@ class SessionsController < ApplicationController
   end
 
   def callback
-    user = User.find_by(username: session["current_authentication"]["username"])
-    raise "user #{session["current_authentication"]["username"]} never initiated sign up" unless user
+    user = User.find_by(username: session[:current_authentication][:username])
+    raise "user #{session[:current_authentication][:username]} never initiated sign up" unless user
 
     begin
       verified_webauthn_credential, stored_credential = relying_party.verify_authentication(
         params,
-        session["current_authentication"]["challenge"],
+        session[:current_authentication][:challenge],
         user_verification: true,
       ) do |webauthn_credential|
         user.credentials.find_by(external_id: Base64.strict_encode64(webauthn_credential.raw_id))
@@ -45,7 +45,7 @@ class SessionsController < ApplicationController
     rescue WebAuthn::Error => e
       render json: "Verification failed: #{e.message}", status: :unprocessable_entity
     ensure
-      session.delete("current_authentication")
+      session.delete(:current_authentication)
     end
   end
 


### PR DESCRIPTION
First of all, this sample application was very useful for my development. Thank you for creating it.
I've made changes to this repository to make it even more useful.

Since `Ruby` distinguishes between `string` and `symbol` when accessing data with `Hash#[]`, unexpected data retrieval will occur, for example, as shown below.

```ruby
session[:current_registration]
=> {:challenge=>"MU76pUDRlTBGut7yigvg_TsiEYy87VvYhOthtomV6Ss"}

session["current_registration"]
=> {:challenge=>"MU76pUDRlTBGut7yigvg_TsiEYy87VvYhOthtomV6Ss"}

# Unable to obtain expected data
session["current_registration"]["challenge"]
=> nil

session["current_registration"][:challenge]
=> "MU76pUDRlTBGut7yigvg_TsiEYy87VvYhOthtomV6Ss"

session[:current_registration][:challenge]
=> "MU76pUDRlTBGut7yigvg_TsiEYy87VvYhOthtomV6Ss"
```

Unify the `key` specification method when acquiring data of `Hash` class to `symbol`.

