### PR TITLE
Use SQLite instead of Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
@@ -36,10 +22,6 @@ jobs:
     - name: Run tests
       env:
         RAILS_ENV: test
-        DB_USER: postgres
-        DB_PASSWORD: postgres
-        PGHOST: localhost
-        PGPORT: 5432
       run: |
         bundle exec rake db:create db:schema:load
         bundle exec rake

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Generate kamal secrets
         run: |
           cat <<EOT >> .kamal/secrets
-            DATABASE_URL=${{secrets.DATABASE_URL}}
             RAILS_MASTER_KEY=${{secrets.RAILS_MASTER_KEY}}
           EOT
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,15 +7,15 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
-
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+
+# Ignore storage (uploaded files in development and any SQLite databases).
+/storage/*
+!/storage/.keep
 
 /public/assets
 .byebug_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=build /rails /rails
 # Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R rails:rails db log tmp
+    chown -R rails:rails db log tmp storage
 USER 1000:1000
 
 # Entrypoint prepares the database.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libpq-dev libjemalloc2
+    apt-get install --no-install-recommends -y curl libjemalloc2
 
 # Set production environment
 ENV RAILS_ENV="production" \

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "webauthn", "~> 3.1"
 
 gem 'bootsnap', '~> 1.17', require: false
 gem 'importmap-rails', '~> 2.0'
-gem 'pg', '~> 1.5'
+gem 'sqlite3', '>= 1.4'
 gem 'puma', '~> 6.4'
 gem "rollbar", "~> 3.6"
 gem 'sassc-rails', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ gem "webauthn", "~> 3.1"
 
 gem 'bootsnap', '~> 1.17', require: false
 gem 'importmap-rails', '~> 2.0'
-gem 'sqlite3', '>= 1.4'
 gem 'puma', '~> 6.4'
 gem "rollbar", "~> 3.6"
 gem 'sassc-rails', '~> 2.0'
+gem 'sqlite3', '>= 1.4'
 gem 'stimulus-rails', '~> 1.3'
 
 group :development, :deploy do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,6 @@ GEM
     parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
-    pg (1.5.8)
     psych (5.1.2)
       stringio
     public_suffix (6.0.1)
@@ -283,6 +282,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (2.1.0)
+      mini_portile2 (~> 2.8.0)
     sshkit (1.23.1)
       base64
       net-scp (>= 1.1.2)
@@ -337,7 +338,6 @@ DEPENDENCIES
   importmap-rails (~> 2.0)
   kamal (~> 2.1)
   minitest-stub_any_instance (~> 1.0)
-  pg (~> 1.5)
   puma (~> 6.4)
   rack-mini-profiler (~> 3.3)
   rails (~> 7.1.3)
@@ -346,6 +346,7 @@ DEPENDENCIES
   rubocop-rails (~> 2.26)
   sassc-rails (~> 2.0)
   selenium-webdriver (~> 4.25)
+  sqlite3 (>= 1.4)
   stimulus-rails (~> 1.3)
   web-console (~> 4.2, >= 4.2.1)
   webauthn (~> 3.1)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ If you want to see an implementation of WebAuthn as a second factor authenticato
 #### Prerequisites
 
 * Ruby
-* PostgreSQL
 
 #### Setup
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,87 +1,25 @@
-# PostgreSQL. Versions 9.1 and up are supported.
+# SQLite. Versions 3.8.0 and up are supported.
+#   gem install sqlite3
 #
-# Install the pg driver:
-#   gem install pg
-# On OS X with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On OS X with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem "sqlite3"
 #
 default: &default
-  adapter: postgresql
-  encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
 
 development:
   <<: *default
-  database: webauthn-app_development
-
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: webauthn-app
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
+  database: storage/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: webauthn-app_test
-  username: <%= ENV["DB_USER"] %>
-  password: <%= ENV["DB_PASSWORD"] %>
+  database: storage/test.sqlite3
 
-# As with config/secrets.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
 production:
   <<: *default
-  database: webauthn-app_production
-  username: webauthn-app
-  password: <%= ENV['WEBAUTHN-APP_DATABASE_PASSWORD'] %>
+  database: storage/production.sqlite3

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -28,7 +28,6 @@ env:
     LANG: en_US.UTF-8
   secret:
     - RAILS_MASTER_KEY
-    - DATABASE_URL
 
 ssh:
   user: ubuntu

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,25 +2,21 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2020_04_11_210422) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
+ActiveRecord::Schema[7.1].define(version: 2020_04_11_210422) do
   create_table "credentials", force: :cascade do |t|
     t.string "external_id"
     t.string "public_key"
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "nickname"
     t.bigint "sign_count", default: 0, null: false
     t.index ["external_id"], name: "index_credentials_on_external_id", unique: true
@@ -29,8 +25,8 @@ ActiveRecord::Schema[6.1].define(version: 2020_04_11_210422) do
 
   create_table "users", force: :cascade do |t|
     t.string "username"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "webauthn_id"
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
This is a proposal to start using SQLite instead of Postgres, to simplify the setup and deployment a little bit.

Since this is just a demo app, it feels like it doesn't really need a Postgres server, and SQLite might just be enough.

SQLite can probably be tweaked to have better performance, but felt like it wasn't worth it for this case.

For the Kamal/Docker container i decided not to map the db file to the host machine (so the DB will be lost on every deploy) to keep things simple, but also thinking it might not be a bad idea to reset the DB now and then (open to discussion though!)