### PR TITLE
Don't run deploy workflow on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'cedarcode/webauthn-rails-demo-app'
+
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
Followed this example: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository