### PR TITLE
Use global `WebAuthn::Credential` instead of custom `WebAuthn::RelyingParty`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,12 +19,4 @@ class ApplicationController < ActionController::Base
         User.find_by(id: session[:user_id])
       end
   end
-
-  def relying_party
-    @relying_party ||=
-      WebAuthn::RelyingParty.new(
-        origin: Rails.configuration.webauthn_origin,
-        name: "WebAuthn Rails Demo App"
-      )
-  end
 end

--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -2,7 +2,7 @@
 
 class CredentialsController < ApplicationController
   def create
-    create_options = relying_party.options_for_registration(
+    create_options = WebAuthn::Credential.options_for_create(
       user: {
         id: current_user.webauthn_id,
         name: current_user.username,
@@ -19,29 +19,29 @@ class CredentialsController < ApplicationController
   end
 
   def callback
-    webauthn_credential = relying_party.verify_registration(
-      params,
-      session[:current_registration]["challenge"],
-      user_verification: true,
-    )
+    webauthn_credential = WebAuthn::Credential.from_create(params)
 
-    credential = current_user.credentials.find_or_initialize_by(
-      external_id: Base64.strict_encode64(webauthn_credential.raw_id)
-    )
+    begin
+      webauthn_credential.verify(session[:current_registration]["challenge"], user_verification: true)
 
-    if credential.update(
-      nickname: params[:credential_nickname],
-      public_key: webauthn_credential.public_key,
-      sign_count: webauthn_credential.sign_count
-    )
-      render json: { status: "ok" }, status: :ok
-    else
-      render json: "Couldn't add your Security Key", status: :unprocessable_entity
+      credential = current_user.credentials.find_or_initialize_by(
+        external_id: Base64.strict_encode64(webauthn_credential.raw_id)
+      )
+
+      if credential.update(
+        nickname: params[:credential_nickname],
+        public_key: webauthn_credential.public_key,
+        sign_count: webauthn_credential.sign_count
+      )
+        render json: { status: "ok" }, status: :ok
+      else
+        render json: "Couldn't add your Security Key", status: :unprocessable_entity
+      end
+    rescue WebAuthn::Error => e
+      render json: "Verification failed: #{e.message}", status: :unprocessable_entity
+    ensure
+      session.delete(:current_registration)
     end
-  rescue WebAuthn::Error => e
-    render json: "Verification failed: #{e.message}", status: :unprocessable_entity
-  ensure
-    session.delete(:current_registration)
   end
 
   def destroy

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -7,7 +7,7 @@ class RegistrationsController < ApplicationController
   def create
     user = User.new(username: params[:registration][:username])
 
-    create_options = relying_party.options_for_registration(
+    create_options = WebAuthn::Credential.options_for_create(
       user: {
         name: params[:registration][:username],
         id: user.webauthn_id
@@ -29,14 +29,12 @@ class RegistrationsController < ApplicationController
   end
 
   def callback
+    webauthn_credential = WebAuthn::Credential.from_create(params)
+
     user = User.create!(session[:current_registration]["user_attributes"])
 
     begin
-      webauthn_credential = relying_party.verify_registration(
-        params,
-        session[:current_registration]["challenge"],
-        user_verification: true,
-      )
+      webauthn_credential.verify(session[:current_registration]["challenge"], user_verification: true)
 
       credential = user.credentials.build(
         external_id: Base64.strict_encode64(webauthn_credential.raw_id),

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
     user = User.find_by(username: session_params[:username])
 
     if user
-      get_options = relying_party.options_for_authentication(
+      get_options = WebAuthn::Credential.options_for_get(
         allow: user.credentials.pluck(:external_id),
         user_verification: "required"
       )
@@ -26,19 +26,22 @@ class SessionsController < ApplicationController
   end
 
   def callback
+    webauthn_credential = WebAuthn::Credential.from_get(params)
+
     user = User.find_by(username: session[:current_authentication]["username"])
     raise "user #{session[:current_authentication]["username"]} never initiated sign up" unless user
 
-    begin
-      verified_webauthn_credential, stored_credential = relying_party.verify_authentication(
-        params,
-        session[:current_authentication]["challenge"],
-        user_verification: true,
-      ) do |webauthn_credential|
-        user.credentials.find_by(external_id: Base64.strict_encode64(webauthn_credential.raw_id))
-      end
+    credential = user.credentials.find_by(external_id: Base64.strict_encode64(webauthn_credential.raw_id))
 
-      stored_credential.update!(sign_count: verified_webauthn_credential.sign_count)
+    begin
+      webauthn_credential.verify(
+        session[:current_authentication]["challenge"],
+        public_key: credential.public_key,
+        sign_count: credential.sign_count,
+        user_verification: true,
+      )
+
+      credential.update!(sign_count: webauthn_credential.sign_count)
       sign_in(user)
 
       render json: { status: "ok" }, status: :ok

--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+WebAuthn.configure do |config|
+  config.origin = Rails.configuration.webauthn_origin
+  config.rp_name = "WebAuthn Rails Demo App"
+end


### PR DESCRIPTION
If I understand correctly, the [Readme](https://github.com/cedarcode/webauthn-ruby/blob/f030a78bd14999ce4905b74df92d8ca548832455/README.md#configuration) and [docs](https://github.com/cedarcode/webauthn-ruby/blob/f030a78bd14999ce4905b74df92d8ca548832455/docs/advanced_configuration.md#instance-based-configuration) suggest that `WebAuthn::RelyingParty` is for advanced usages where you need multiple origins? So it feels like the demo should show the simpler use case where you only need one origin

Looks like the reverse change was done in https://github.com/cedarcode/webauthn-rails-demo-app/pull/117 (maybe to show how the instance based config worked), so I'm ok if you prefer to keep this as-is