### PR TITLE
documentation: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ If you want to see an implementation of WebAuthn as a second factor authenticato
 ```
 $ git clone https://github.com/cedarcode/webauthn-rails-demo-app
 $ cd webauthn-rails-demo-app/
-$ cp .env.example .env
 $ bundle install
 $ bundle exec rake db:setup
 ```


### PR DESCRIPTION
I noticed that the documentation on the main page has drifted slightly from the implementation, the configuration is now set in `config/environments/development.rb` and `config/environments/test.rb` respectively and as a result, this line is no longer required.