### PR TITLE
Remove `webauthn-json` dependency

### DIFF
--- a/app/controllers/credentials_controller.rb
+++ b/app/controllers/credentials_controller.rb
@@ -25,7 +25,7 @@ class CredentialsController < ApplicationController
       webauthn_credential.verify(session[:current_registration]["challenge"], user_verification: true)
 
       credential = current_user.credentials.find_or_initialize_by(
-        external_id: Base64.strict_encode64(webauthn_credential.raw_id)
+        external_id: webauthn_credential.id
       )
 
       if credential.update(

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -37,7 +37,7 @@ class RegistrationsController < ApplicationController
       webauthn_credential.verify(session[:current_registration]["challenge"], user_verification: true)
 
       user.credentials.build(
-        external_id: Base64.strict_encode64(webauthn_credential.raw_id),
+        external_id: webauthn_credential.id,
         nickname: params[:credential_nickname],
         public_key: webauthn_credential.public_key,
         sign_count: webauthn_credential.sign_count

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,7 +31,7 @@ class SessionsController < ApplicationController
     user = User.find_by(username: session[:current_authentication]["username"])
     raise "user #{session[:current_authentication]["username"]} never initiated sign up" unless user
 
-    credential = user.credentials.find_by(external_id: Base64.strict_encode64(webauthn_credential.raw_id))
+    credential = user.credentials.find_by(external_id: webauthn_credential.id)
 
     begin
       webauthn_credential.verify(

--- a/app/javascript/controllers/feature_detection_controller.js
+++ b/app/javascript/controllers/feature_detection_controller.js
@@ -1,20 +1,14 @@
 import { Controller } from "@hotwired/stimulus";
-import { supported as WebAuthnSupported } from "@github/webauthn-json";
 
 export default class extends Controller {
   static targets = ["message"]
 
   connect() {
-    if (!WebAuthnSupported()) {
-      this.messageTarget.innerHTML = "This browser doesn't support WebAuthn API";
-      this.element.classList.remove("hidden");
-    } else {
-      PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable().then((available) => {
-        if (!available) {
-          this.messageTarget.innerHTML = "We couldn't detect a user-verifying platform authenticator";
-          this.element.classList.remove("hidden");
-        }
-      });
-    }
+    PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable().then((available) => {
+      if (!available) {
+        this.messageTarget.innerHTML = "We couldn't detect a user-verifying platform authenticator";
+        this.element.classList.remove("hidden");
+      }
+    });
   }
 }

--- a/app/javascript/credential.js
+++ b/app/javascript/credential.js
@@ -1,4 +1,3 @@
-import * as WebAuthnJSON from "@github/webauthn-json"
 import { showMessage } from "messenger";
 
 function getCSRFToken() {
@@ -31,8 +30,10 @@ function callback(url, body) {
   });
 }
 
-function create(callbackUrl, credentialOptions) {
-  WebAuthnJSON.create({ "publicKey": credentialOptions }).then(function(credential) {
+function create(callbackUrl, data) {
+  const credentialOptions = PublicKeyCredential.parseCreationOptionsFromJSON(data);
+
+  navigator.credentials.create({ "publicKey": credentialOptions }).then(function(credential) {
     callback(callbackUrl, credential);
   }).catch(function(error) {
     showMessage(error);
@@ -41,8 +42,10 @@ function create(callbackUrl, credentialOptions) {
   console.log("Creating new public key credential...");
 }
 
-function get(credentialOptions) {
-  WebAuthnJSON.get({ "publicKey": credentialOptions }).then(function(credential) {
+function get(data) {
+  const credentialOptions = PublicKeyCredential.parseRequestOptionsFromJSON(data);
+
+  navigator.credentials.get({ "publicKey": credentialOptions }).then(function(credential) {
     callback("/session/callback", credential);
   }).catch(function(error) {
     showMessage(error);

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -12,7 +12,6 @@ pin "@material/menu", to: "https://ga.jspm.io/npm:@material/menu@4.0.0/dist/mdc.
 pin "@material/snackbar", to: "https://ga.jspm.io/npm:@material/snackbar@4.0.0/dist/mdc.snackbar.js"
 pin "@material/textfield", to: "https://ga.jspm.io/npm:@material/textfield@4.0.0/dist/mdc.textfield.js"
 pin "@material/top-app-bar", to: "https://ga.jspm.io/npm:@material/top-app-bar@4.0.0/dist/mdc.topAppBar.js"
-pin "@github/webauthn-json", to: "https://ga.jspm.io/npm:@github/webauthn-json@2.1.1/dist/esm/webauthn-json.js"
 
 # turbolinks
 pin "turbolinks", to: "https://ga.jspm.io/npm:turbolinks@5.2.0/dist/turbolinks.js"

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -47,7 +47,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
       username: "bob",
       credentials: [
         Credential.new(
-          external_id: Base64.strict_encode64(webauthn_credential.raw_id),
+          external_id: webauthn_credential.id,
           nickname: "Bob's USB Key",
           public_key: webauthn_credential.public_key,
           sign_count: webauthn_credential.sign_count


### PR DESCRIPTION
#### Summary
Stop using `@github/webauthn-json` dependency and start using `navigator.credentials` native API calls instead.

#### Why?
`webauthn-json` has been deprecated: https://github.com/github/webauthn-json/pull/94